### PR TITLE
Cleaned up POM and added extensions.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,3 @@ nb-configuration.xml
 ## OS X
 ##############################
 .DS_Store
-
-.mvn/
-.idea/

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,18 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.25</version>
+    <version>4.28</version>
     <relativePath/>
   </parent>
 
   <groupId>io.jenkins.plugins</groupId>
   <artifactId>keeper-secrets-manager</artifactId>
-  <!-- <version>${revision}-${changelist}</version> -->
-  <version>${revision}-${changelist}</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <properties>
     <revision>1.0</revision>
-    <changelist>999999-SNAPSHOT</changelist>
+    <changelist></changelist>
     <jenkins.version>2.277.1</jenkins.version>
     <java.level>8</java.level>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -29,19 +28,13 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.277.x</artifactId>
-        <version>950.v396cb834de1e</version>
+        <version>961.vf0c9f6f59827</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jsch</artifactId>
-      <version>0.1.55</version>
-      <optional>true</optional>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
@@ -136,18 +129,6 @@
       <artifactId>workflow-support</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>5.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>30.1.1-jre</version>
-      <!-- <scope>test</scope> -->
     </dependency>
   </dependencies>
   <licenses>


### PR DESCRIPTION
And remove .mvn from .gitignore. This was a sore spot. Either
something added entries to a .gitignore or I used one from
someplace but it ignored the .mvn directory which caused
the maven.config and extenstion.xml not to be commited. I
manaually added the maven.config, but missed the extenstion.xml.

Removed some deps which may have been used with test related modules. This
modules apparently are no longer being used and the project build
fine without them

Update some module based on the newer archetypes.

Also removed SNAPSHOT per a messge from the Google groups.